### PR TITLE
send object directly

### DIFF
--- a/meepo/apps/eventsourcing/prepare_commit.py
+++ b/meepo/apps/eventsourcing/prepare_commit.py
@@ -135,8 +135,8 @@ class RedisPrepareCommit(PrepareCommit):
         sp_key, sp_hkey = self._keygen(session)
 
         def _get_dump_value(value):
-            if hasattr(value, 'pk'):
-                return value.pk
+            if hasattr(value, '__mapper__'):
+                return value.__mapper__.primary_key[0].name
             return value
         pickled_event = {
             k: pickle.dumps({_get_dump_value(obj) for obj in objs})

--- a/meepo/apps/eventsourcing/prepare_commit.py
+++ b/meepo/apps/eventsourcing/prepare_commit.py
@@ -133,7 +133,13 @@ class RedisPrepareCommit(PrepareCommit):
             return
 
         sp_key, sp_hkey = self._keygen(session)
-        pickled_event = {k: pickle.dumps(obj.pk) for k, obj in event.items()}
+
+        def _get_dump_value(value):
+            if hasattr(value, 'pk'):
+                return value.pk
+            return value
+        pickled_event = {k: pickle.dumps({
+            _get_dump_value(obj) for obj in objs}) for k, objs in event.items()}
         with self.r.pipeline(transaction=False) as p:
             p.sadd(sp_key, session.meepo_unique_id)
             p.hmset(sp_hkey, pickled_event)

--- a/meepo/apps/eventsourcing/prepare_commit.py
+++ b/meepo/apps/eventsourcing/prepare_commit.py
@@ -134,9 +134,16 @@ class RedisPrepareCommit(PrepareCommit):
 
         sp_key, sp_hkey = self._keygen(session)
 
+        def _pk(obj):
+            pk_values = tuple(getattr(obj, c.name)
+                              for c in obj.__mapper__.primary_key)
+            if len(pk_values) == 1:
+                return pk_values[0]
+            return pk_values
+
         def _get_dump_value(value):
             if hasattr(value, '__mapper__'):
-                return value.__mapper__.primary_key[0].name
+                return _pk(value)
             return value
         pickled_event = {
             k: pickle.dumps({_get_dump_value(obj) for obj in objs})

--- a/meepo/apps/eventsourcing/prepare_commit.py
+++ b/meepo/apps/eventsourcing/prepare_commit.py
@@ -133,7 +133,7 @@ class RedisPrepareCommit(PrepareCommit):
             return
 
         sp_key, sp_hkey = self._keygen(session)
-        pickled_event = {k: pickle.dumps(v) for k, v in event.items()}
+        pickled_event = {k: pickle.dumps(obj.pk) for k, obj in event.items()}
         with self.r.pipeline(transaction=False) as p:
             p.sadd(sp_key, session.meepo_unique_id)
             p.hmset(sp_hkey, pickled_event)

--- a/meepo/apps/eventsourcing/prepare_commit.py
+++ b/meepo/apps/eventsourcing/prepare_commit.py
@@ -138,8 +138,9 @@ class RedisPrepareCommit(PrepareCommit):
             if hasattr(value, 'pk'):
                 return value.pk
             return value
-        pickled_event = {k: pickle.dumps({
-            _get_dump_value(obj) for obj in objs}) for k, objs in event.items()}
+        pickled_event = {
+            k: pickle.dumps({_get_dump_value(obj) for obj in objs})
+            for k, objs in event.items()}
         with self.r.pipeline(transaction=False) as p:
             p.sadd(sp_key, session.meepo_unique_id)
             p.hmset(sp_hkey, pickled_event)

--- a/meepo/apps/eventsourcing/pub.py
+++ b/meepo/apps/eventsourcing/pub.py
@@ -91,7 +91,7 @@ class sqlalchemy_es_pub(sqlalchemy_pub):
                         if o.__table__.fullname in self.tables]
             for obj in objs:
                 evt_name = "%s_%s" % (obj.__table__.fullname, action)
-                evt[evt_name].add(self._pk(obj))
+                evt[evt_name].add(obj)
                 self.logger.debug("%s - session_prepare: %s -> %s" % (
                     session.meepo_unique_id, evt_name, evt))
 

--- a/tests/test_eventsourcing/test_prepare_commit.py
+++ b/tests/test_eventsourcing/test_prepare_commit.py
@@ -44,7 +44,7 @@ def test_redis_prepare_commit_phase(mock_session, redis_pc):
 
 def test_redis_strict_prepare_commit_phase(mock_session, redis_strict_pc):
     with pytest.raises(redis.ConnectionError):
-        redis_strict_pc.prepare(mock_session, {"test_write": 1})
+        redis_strict_pc.prepare(mock_session, {"test_write": {1}})
 
     with pytest.raises(redis.ConnectionError):
         redis_strict_pc.commit(mock_session)

--- a/tests/test_eventsourcing/test_sqlalchemy_es_pub.py
+++ b/tests/test_eventsourcing/test_sqlalchemy_es_pub.py
@@ -116,7 +116,9 @@ def test_sa_single_write(session, model_cls):
     session.commit()
 
     event, sid = s_events.pop(), s_commits.pop()
-    assert event == {"sid": sid, "event": {"test_write": {t_a.id}}}
+    assert event['sid'] == sid
+    obj = event['event']['test_write'].pop()
+    assert obj.id == t_a.id
 
     assert t_writes == [t_a.id]
     assert [t_updates, t_deletes, s_rollbacks] == [[]] * 3
@@ -131,7 +133,9 @@ def test_sa_single_flush_write(session, model_cls):
     session.commit()
 
     event, sid = s_events.pop(), s_commits.pop()
-    assert event == {"sid": sid, "event": {"test_write": {t_b.id}}}
+    assert event['sid'] == sid
+    obj = event['event']['test_write'].pop()
+    assert obj.id == t_b.id
 
     assert t_writes == [t_b.id]
     assert [t_updates, t_deletes, s_rollbacks] == [[]] * 3
@@ -146,7 +150,9 @@ def test_sa_multi_writes(session, model_cls):
     session.commit()
 
     event, sid = s_events.pop(), s_commits.pop()
-    assert event == {"sid": sid, "event": {"test_write": {t_c.id, t_d.id}}}
+    assert event['sid'] == sid
+    obj = event['event']['test_write'].pop()
+    assert obj.id == t_d.id
 
     assert set(t_writes) == {t_c.id, t_d.id}
     assert [t_updates, t_deletes, s_rollbacks] == [[]] * 3
@@ -159,7 +165,9 @@ def test_sa_single_update(session, model_cls):
     session.commit()
 
     event, sid = s_events.pop(), s_commits.pop()
-    assert event == {"sid": sid, "event": {"test_update": {t_a.id}}}
+    assert event['sid'] == sid
+    obj = event['event']['test_update'].pop()
+    assert obj.id == t_a.id
 
     assert set(t_updates) == {t_a.id}
     assert [t_writes, t_deletes, s_rollbacks] == [[]] * 3
@@ -173,7 +181,9 @@ def test_sa_single_flush_update(session, model_cls):
     session.commit()
 
     event, sid = s_events.pop(), s_commits.pop()
-    assert event == {"sid": sid, "event": {"test_update": {t_a.id}}}
+    assert event['sid'] == sid
+    obj = event['event']['test_update'].pop()
+    assert obj.id == t_a.id
 
     assert set(t_updates) == {t_a.id}
     assert [t_writes, t_deletes, s_rollbacks] == [[]] * 3
@@ -206,13 +216,22 @@ def test_sa_mixed_write_update_delete_and_multi_flushes(session, model_cls):
 
     # since the commit include a flush in it, two events will be triggered and
     # the later event contains the first event.
-    assert s_events[0] == {"sid": sid,
-                           "event": {"test_write": {t_e.id},
-                                     "test_update": {t_b.id}}}
-    assert s_events[1] == {"sid": sid,
-                           "event": {"test_write": {t_e.id},
-                                     "test_update": {t_b.id},
-                                     "test_delete": {t_c.id}}}
+    event = s_events[0]
+    assert event['sid'] == sid
+    write_obj = event['event']['test_write'].pop()
+    update_obj = event['event']['test_update'].pop()
+    assert write_obj.id == t_e.id
+    assert update_obj.id == t_b.id
+
+    event = s_events[1]
+
+    assert event['sid'] == sid
+    write_obj = event['event']['test_write'].pop()
+    update_obj = event['event']['test_update'].pop()
+    delete_obj = event['event']['test_delete'].pop()
+    assert write_obj.id == t_e.id
+    assert update_obj.id == t_b.id
+    assert delete_obj.id == t_c.id
 
 
 def test_sa_empty_rollback(session):
@@ -245,7 +264,9 @@ def test_sa_flush_rollback(session, model_cls):
     session.rollback()
 
     event, sid = s_events.pop(), s_rollbacks.pop()
-    assert event == {"sid": sid, "event": {"test_write": {t_e.id}}}
+    assert event['sid'] == sid
+    obj = event['event']['test_write'].pop()
+    assert obj.id == t_e.id
 
     assert [t_writes, t_updates, t_deletes, s_commits] == [[]] * 4
 
@@ -253,7 +274,7 @@ def test_sa_flush_rollback(session, model_cls):
 def test_sa_multi_sessions(session, session_b, model_cls):
     def _sp_for_b(s, event):
         assert s.info == session_b.info
-        assert event == {"test_write": {t_g.id}}
+        assert event['test_write'].pop().id == t_g.id
     signal("session_prepare").connect(_sp_for_b, sender=session_b, weak=False)
 
     t_f = model_cls(data='f')

--- a/tests/test_eventsourcing/test_sqlalchemy_es_pub.py
+++ b/tests/test_eventsourcing/test_sqlalchemy_es_pub.py
@@ -151,8 +151,8 @@ def test_sa_multi_writes(session, model_cls):
 
     event, sid = s_events.pop(), s_commits.pop()
     assert event['sid'] == sid
-    obj = event['event']['test_write'].pop()
-    assert obj.id == t_d.id
+    objs = event['event']['test_write']
+    assert {obj.id for obj in objs} == {t_c.id, t_d.id}
 
     assert set(t_writes) == {t_c.id, t_d.id}
     assert [t_updates, t_deletes, s_rollbacks] == [[]] * 3


### PR DESCRIPTION
@maralla 
这个是为了在zeus直接通过obj取到model，而不用去model map查了，
下面是改过之后的`install_cache_delete_hook`方法,详细的见https://github.com/eleme/zeus2/pull/2899

```
def install_cache_delete_hook(session, redis_regions):
    """Cache delete hooks to session_prepare, and should only be used
    together with event sourcing.
    """
    logger = logging.getLogger("%s.del" % redis_regions[0].namespace)

    logger.info("cache delete hook enabled for session: %s" % session.info)

    def _sp_sub(session, event):
        keys = []
        for event, models in event.items():
            table = event[:event.rfind('_')]
            keys.extend(itertools.chain(
                (model.gen_raw_key(model.pk) for model in models),
                (model.gen_raw_key(model.pk, serialized=True) for model in models))
            )
            logger.info("table cache deleted: %s -> %s" % (
                table, [model.pk for model in models]
            ))
        for r in redis_regions:
            r.delete(*set(keys))
    signal("session_prepare").connect(_sp_sub, sender=session, weak=False)
```
